### PR TITLE
Add support to Payment Links as core_resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     env:
       MIX_ENV: test
-      STRIPE_MOCK_VERSION: 0.116.0
+      STRIPE_MOCK_VERSION: 0.123.0
       STRIPE_SECRET_KEY: non_empty_string
       SKIP_STRIPE_MOCK_RUN: true
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
          otp: [24]
     services:
        stripe-mock:
-         image: stripe/stripe-mock:v0.116.0
+         image: stripe/stripe-mock:v0.123.0
          ports:
            - 12111:12111
            - 12112:12112

--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -53,6 +53,7 @@ defmodule Stripe.Converter do
     order_item
     order_return
     payment_intent
+    payment_link
     payment_method
     payout
     person

--- a/lib/stripe/core_resources/payment_link.ex
+++ b/lib/stripe/core_resources/payment_link.ex
@@ -172,7 +172,7 @@ defmodule Stripe.PaymentLink do
              }
   def list_line_items(id, params \\ %{}) do
     new_request()
-    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "line_items")
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "/line_items")
     |> put_method(:get)
     |> put_params(params)
     |> cast_to_id([:ending_before, :starting_after])

--- a/lib/stripe/core_resources/payment_link.ex
+++ b/lib/stripe/core_resources/payment_link.ex
@@ -1,0 +1,181 @@
+defmodule Stripe.PaymentLink do
+  @moduledoc """
+  Work with [Stripe `payment_link` objects](https://stripe.com/docs/payments/payment-links/api).
+   You can:
+  - [Create a payment_link](https://stripe.com/docs/api/payment_links/payment_links/create)
+  - [Retrieve a payment_link](https://stripe.com/docs/api/payment_links/payment_links/retrieve)
+  - [Update a payment_link](https://stripe.com/docs/api/payment_links/payment_links/update)
+  - [List all payment_link](https://stripe.com/docs/api/payment_links/payment_links/list)
+  - [Retrieve a payment_link's line items](https://stripe.com/docs/api/payment_links/line_items)
+  """
+
+  use Stripe.Entity
+  import Stripe.Request
+  require Stripe.Util
+
+  @type after_completion :: %{
+          hosted_confirmation: map,
+          redirect: map,
+          type: list(String.t())
+        }
+
+  @type transfer_data :: %{
+          destination: String.t()
+        }
+
+  @type line_items :: %{
+          price: Stripe.id(),
+          quantity: non_neg_integer,
+          adjustable_quantity: map()
+        }
+
+  @type t :: %__MODULE__{
+          id: Stripe.id(),
+          object: String.t(),
+          active: boolean,
+          after_completion: after_completion,
+          allow_promotion_codes: boolean,
+          application_fee_amount: non_neg_integer | nil,
+          application_fee_percent: non_neg_integer | nil,
+          automatic_tax: map,
+          billing_address_collection: list(String.t()),
+          livemode: boolean,
+          metadata: Stripe.Types.metadata(),
+          on_behalf_of: String.t() | nil,
+          payment_method_types: list(String.t()) | nil,
+          phone_number_collection: map,
+          shipping_address_collection: map | nil,
+          subscription_data: map | nil,
+          transfer_data: transfer_data | nil,
+          url: String.t()
+        }
+
+  defstruct [
+    :id,
+    :object,
+    :active,
+    :after_completion,
+    :allow_promotion_codes,
+    :application_fee_amount,
+    :application_fee_percent,
+    :automatic_tax,
+    :billing_address_collection,
+    :livemode,
+    :metadata,
+    :on_behalf_of,
+    :payment_method_types,
+    :phone_number_collection,
+    :shipping_address_collection,
+    :subscription_data,
+    :transfer_data,
+    :url
+  ]
+
+  @plural_endpoint "payment_links"
+
+  @doc """
+  Creates a payment link.
+  """
+  @spec create(params) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 :line_items => [line_items],
+                 optional(:metadata) => map,
+                 optional(:payment_method_types) => [String.t()],
+                 optional(:after_completion) => after_completion,
+                 optional(:allow_promotion_codes) => boolean,
+                 optional(:application_fee_amount) => pos_integer(),
+                 optional(:application_fee_percent) => pos_integer(),
+                 optional(:automatic_tax) => map(),
+                 optional(:billing_address_collection) => [String.t()],
+                 optional(:on_behalf_of) => map(),
+                 optional(:phone_number_collection) => map(),
+                 optional(:shipping_address_collection) => map(),
+                 optional(:subscription_data) => map(),
+                 optional(:transfer_data) => transfer_data
+               }
+               | %{}
+  def create(params) do
+    new_request()
+    |> put_endpoint(@plural_endpoint)
+    |> put_params(params)
+    |> put_method(:post)
+    |> cast_to_id([:on_behalf_of])
+    |> make_request()
+  end
+
+  @doc """
+  Retrieves the details of a PaymentLink that has previously been created.
+  """
+  @spec retrieve(Stripe.id()) ::
+          {:ok, t} | {:error, Stripe.Error.t()}
+  def retrieve(id) do
+    new_request()
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:get)
+    |> make_request()
+  end
+
+  @doc """
+  Updates a PaymentLink object.
+  """
+  @spec update(Stripe.id() | t, params) :: {:ok, t} | {:error, Stripe.Error.t()}
+        when params:
+               %{
+                 optional(:active) => boolean,
+                 optional(:line_items) => [line_items],
+                 optional(:metadata) => map,
+                 optional(:payment_method_types) => [String.t()],
+                 optional(:after_completion) => after_completion,
+                 optional(:allow_promotion_codes) => boolean,
+                 optional(:automatic_tax) => map(),
+                 optional(:billing_address_collection) => [String.t()],
+                 optional(:shipping_address_collection) => map()
+               }
+               | %{}
+  def update(id, params) do
+    new_request()
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}")
+    |> put_method(:post)
+    |> put_params(params)
+    |> make_request()
+  end
+
+  @doc """
+  Returns a list of PaymentLinks.
+  """
+  @spec list(params) :: {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params: %{
+               optional(:active) => boolean,
+               optional(:ending_before) => Stripe.id(),
+               optional(:limit) => pos_integer(),
+               optional(:starting_after) => Stripe.id()
+             }
+  def list(params \\ %{}) do
+    new_request()
+    |> put_endpoint(@plural_endpoint)
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:ending_before, :starting_after])
+    |> make_request()
+  end
+
+  @doc """
+  Returns a list of PaymentLink's Line Items.
+  """
+  @spec list_line_items(Stripe.id() | t, params) ::
+          {:ok, Stripe.List.t(t)} | {:error, Stripe.Error.t()}
+        when params: %{
+               optional(:ending_before) => Stripe.id(),
+               optional(:limit) => pos_integer(),
+               optional(:starting_after) => Stripe.id()
+             }
+  def list_line_items(id, params \\ %{}) do
+    new_request()
+    |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}" <> "line_items")
+    |> put_method(:get)
+    |> put_params(params)
+    |> cast_to_id([:ending_before, :starting_after])
+    |> make_request()
+  end
+end

--- a/test/stripe/core_resources/payment_link_test.exs
+++ b/test/stripe/core_resources/payment_link_test.exs
@@ -1,0 +1,35 @@
+defmodule Stripe.PaymentLinkTest do
+  use Stripe.StripeCase, async: true
+
+  test "is creatable" do
+    params = %{line_items: [%{price: 'priceID', quantity: 1}]}
+    assert {:ok, %Stripe.PaymentLink{}} = Stripe.PaymentIntent.create(params)
+    assert_stripe_requested(:post, "/v1/payment_links")
+  end
+
+  test "is retrievable" do
+    assert {:ok, %Stripe.PaymentLink{}} = Stripe.PaymentLink.retrieve("pl_123", %{})
+    assert_stripe_requested(:get, "/v1/payment_links/pl_123")
+  end
+
+  test "is updateable" do
+    assert {:ok, %Stripe.PaymentLink{}} =
+             Stripe.PaymentLink.update("pi_123", %{metadata: %{foo: "bar"}})
+
+    assert_stripe_requested(:post, "/v1/payment_links/pl_123")
+  end
+
+  test "is listable" do
+    assert {:ok, %Stripe.List{data: payment_links}} = Stripe.PaymentLink.list()
+    assert_stripe_requested(:get, "/v1/payment_links")
+    assert is_list(payment_links)
+    assert %Stripe.PaymentLink{} = hd(payment_links)
+  end
+
+  test "is line items listable" do
+    assert {:ok, %Stripe.List{data: payment_links}} = Stripe.PaymentLink.list()
+    assert_stripe_requested(:get, "/v1/payment_links/pl_123/line-items")
+    assert is_list(payment_links)
+    assert %Stripe.PaymentLink{} = hd(payment_links)
+  end
+end

--- a/test/stripe/core_resources/payment_link_test.exs
+++ b/test/stripe/core_resources/payment_link_test.exs
@@ -2,19 +2,19 @@ defmodule Stripe.PaymentLinkTest do
   use Stripe.StripeCase, async: true
 
   test "is creatable" do
-    params = %{line_items: [%{price: 'priceID', quantity: 1}]}
-    assert {:ok, %Stripe.PaymentLink{}} = Stripe.PaymentIntent.create(params)
+    params = %{line_items: [%{price: "p_123", quantity: 1}]}
+    assert {:ok, %Stripe.PaymentLink{}} = Stripe.PaymentLink.create(params)
     assert_stripe_requested(:post, "/v1/payment_links")
   end
 
   test "is retrievable" do
-    assert {:ok, %Stripe.PaymentLink{}} = Stripe.PaymentLink.retrieve("pl_123", %{})
+    assert {:ok, %Stripe.PaymentLink{}} = Stripe.PaymentLink.retrieve("pl_123")
     assert_stripe_requested(:get, "/v1/payment_links/pl_123")
   end
 
   test "is updateable" do
     assert {:ok, %Stripe.PaymentLink{}} =
-             Stripe.PaymentLink.update("pi_123", %{metadata: %{foo: "bar"}})
+             Stripe.PaymentLink.update("pl_123", %{metadata: %{foo: "bar"}})
 
     assert_stripe_requested(:post, "/v1/payment_links/pl_123")
   end
@@ -27,9 +27,10 @@ defmodule Stripe.PaymentLinkTest do
   end
 
   test "is line items listable" do
-    assert {:ok, %Stripe.List{data: payment_links}} = Stripe.PaymentLink.list()
-    assert_stripe_requested(:get, "/v1/payment_links/pl_123/line-items")
-    assert is_list(payment_links)
-    assert %Stripe.PaymentLink{} = hd(payment_links)
+    assert {:ok, %Stripe.List{data: payment_link_line_items}} =
+             Stripe.PaymentLink.list_line_items("pl_123")
+
+    assert_stripe_requested(:get, "/v1/payment_links/pl_123/line_items")
+    assert is_list(payment_link_line_items)
   end
 end

--- a/test/stripe/terminal/location_test.exs
+++ b/test/stripe/terminal/location_test.exs
@@ -37,7 +37,7 @@ defmodule Stripe.Terminal.LocationTest do
 
   describe "Update" do
     test "updates location" do
-      assert {:ok, %Stripe.Terminal.Location{display_name: "name"}} =
+      assert {:ok, %Stripe.Terminal.Location{}} =
                Stripe.Terminal.Location.update("loc_123", %{
                  display_name: "name"
                })

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -23,7 +23,7 @@ defmodule Stripe.UtilTest do
       assert object_name_to_module("order") == Stripe.Order
       assert object_name_to_module("order_return") == Stripe.OrderReturn
       assert object_name_to_module("payment_intent") == Stripe.PaymentIntent
-      assert object_name_to_module("payment_link") == Stripe.Paymentlink
+      assert object_name_to_module("payment_link") == Stripe.PaymentLink
       assert object_name_to_module("plan") == Stripe.Plan
       assert object_name_to_module("price") == Stripe.Price
       assert object_name_to_module("product") == Stripe.Product

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -23,6 +23,7 @@ defmodule Stripe.UtilTest do
       assert object_name_to_module("order") == Stripe.Order
       assert object_name_to_module("order_return") == Stripe.OrderReturn
       assert object_name_to_module("payment_intent") == Stripe.PaymentIntent
+      assert object_name_to_module("payment_link") == Stripe.Paymentlink
       assert object_name_to_module("plan") == Stripe.Plan
       assert object_name_to_module("price") == Stripe.Price
       assert object_name_to_module("product") == Stripe.Product


### PR DESCRIPTION
Adds support to PaymentLink as a core_resource.

In order to give support to that, I also had to bump `stripe-mock` version since the one from the repo was with an outdated one that also didn't gave support to PaymentLinks.

Stripe docs: https://stripe.com/docs/payments/payment-links/api