### PR TITLE
Add bacs_debit to PaymentMethod

### DIFF
--- a/lib/stripe/core_resources/mandate.ex
+++ b/lib/stripe/core_resources/mandate.ex
@@ -35,6 +35,11 @@ defmodule Stripe.Mandate do
             reference: String.t(),
             url: String.t()
           },
+          optional(:bacs_debit) => %{
+            network_status: String.t(),
+            reference: String.t(),
+            url: String.t()
+          },
           type: String.t()
         }
 

--- a/lib/stripe/payment_methods/payment_method.ex
+++ b/lib/stripe/payment_methods/payment_method.ex
@@ -22,6 +22,12 @@ defmodule Stripe.PaymentMethod do
           last4: String.t() | nil
         }
 
+  @type bacs_debit :: %{
+          fingerprint: String.t() | nil,
+          last4: String.t() | nil,
+          sort_code: String.t() | nil
+        }
+
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
@@ -39,6 +45,7 @@ defmodule Stripe.PaymentMethod do
           metadata: Stripe.Types.metadata(),
           au_becs_debit: au_becs_debit() | nil,
           sepa_debit: sepa_debit() | nil,
+          bacs_debit: bacs_debit() | nil,
           type: String.t()
         }
 
@@ -54,6 +61,7 @@ defmodule Stripe.PaymentMethod do
     :metadata,
     :au_becs_debit,
     :sepa_debit,
+    :bacs_debit,
     :type
   ]
 


### PR DESCRIPTION
The bacs_debit field is missing from the PaymentMethod object. https://stripe.com/docs/api/payment_methods/object#payment_method_object-bacs_debit