### PR TITLE
Rename customer cash_balance to update_cash_balance

### DIFF
--- a/lib/stripe/core_resources/customer.ex
+++ b/lib/stripe/core_resources/customer.ex
@@ -208,16 +208,16 @@ defmodule Stripe.Customer do
   Example:  Change reconcilation mode to manual
 
     params = %{settings: %{reconciliation_mode: "manual"}}
-    {:ok, cash_Balance} = Stripe.Customer.cash_balance("cus_123")
+    {:ok, cash_Balance} = Stripe.Customer.update_cash_balance("cus_123")
 
   """
-  @spec cash_balance(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
+  @spec update_cash_balance(Stripe.id() | t, params, Stripe.options()) :: {:ok, t} | {:error, Stripe.Error.t()}
         when params:
                %{
                  optional(:settings) => Stripe.Types.metadata()
                }
                | %{}
-  def cash_balance(id, params, opts \\ []) do
+  def update_cash_balance(id, params, opts \\ []) do
     new_request(opts)
     |> put_endpoint(@plural_endpoint <> "/#{get_id!(id)}/cash_balance")
     |> put_method(:post)

--- a/test/stripe/core_resources/customer_test.exs
+++ b/test/stripe/core_resources/customer_test.exs
@@ -42,10 +42,10 @@ defmodule Stripe.CustomerTest do
     end
   end
 
-  describe "cash_balance/3" do
+  describe "update_cash_balance/3" do
     test "changes settings to customer cash balance" do
       params = %{settings: %{reconciliation_mode: "manual"}}
-      assert {:ok, _} = Stripe.Customer.cash_balance("cus_123", params)
+      assert {:ok, _} = Stripe.Customer.update_cash_balance("cus_123", params)
       assert_stripe_requested(:post, "/v1/customers/cus_123/cash_balance")
     end
   end


### PR DESCRIPTION
Updating function cash_balance to update_cash_balance in order to follow Stripe convention name(Example: [Stripe ruby client)](https://stripe.com/docs/api/cash_balance/update?lang=ruby)