### PR TITLE
Add us_bank_account to PaymentMethod

### DIFF
--- a/lib/stripe/core_resources/mandate.ex
+++ b/lib/stripe/core_resources/mandate.ex
@@ -40,6 +40,10 @@ defmodule Stripe.Mandate do
             reference: String.t(),
             url: String.t()
           },
+          optional(:us_bank_account) =>
+            %{
+              # The docs list this as a hash with no attributes.
+            },
           type: String.t()
         }
 

--- a/lib/stripe/payment_methods/payment_method.ex
+++ b/lib/stripe/payment_methods/payment_method.ex
@@ -27,7 +27,16 @@ defmodule Stripe.PaymentMethod do
           last4: String.t() | nil,
           sort_code: String.t() | nil
         }
-
+  @type us_bank_account :: %{
+          account_holder_type: String.t() | nil,
+          account_type: String.t() | nil,
+          bank_name: String.t() | nil,
+          financial_connections_account: String.t() | nil,
+          fingerprint: String.t() | nil,
+          last4: String.t() | nil,
+          networks: %{preferred: String.t() | nil, supported: list | nil} | nil,
+          routing_number: String.t() | nil
+        }
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),
@@ -46,6 +55,7 @@ defmodule Stripe.PaymentMethod do
           au_becs_debit: au_becs_debit() | nil,
           sepa_debit: sepa_debit() | nil,
           bacs_debit: bacs_debit() | nil,
+          us_bank_account: us_bank_account() | nil,
           type: String.t()
         }
 
@@ -62,6 +72,7 @@ defmodule Stripe.PaymentMethod do
     :au_becs_debit,
     :sepa_debit,
     :bacs_debit,
+    :us_bank_account,
     :type
   ]
 

--- a/lib/stripe/payment_methods/payment_method.ex
+++ b/lib/stripe/payment_methods/payment_method.ex
@@ -27,6 +27,7 @@ defmodule Stripe.PaymentMethod do
           last4: String.t() | nil,
           sort_code: String.t() | nil
         }
+
   @type us_bank_account :: %{
           account_holder_type: String.t() | nil,
           account_type: String.t() | nil,
@@ -37,6 +38,7 @@ defmodule Stripe.PaymentMethod do
           networks: %{preferred: String.t() | nil, supported: list | nil} | nil,
           routing_number: String.t() | nil
         }
+
   @type t :: %__MODULE__{
           id: Stripe.id(),
           object: String.t(),


### PR DESCRIPTION
The us_bank_account field is missing from the PaymentMethod object. https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account

PS: some of the changes are cherry-picked from https://github.com/beam-community/stripity-stripe/pull/742